### PR TITLE
Fix MIT License Compliance (Add Original Copyright)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,8 @@
 MIT License
 
+Copyright (c) 2024 Gabriel de Rezende Gonçalves  
+Original project: https://github.com/gabireze/tiktok-all-reposted-videos-remover
+
 Copyright (c) 2025 Mohammed Mostafa
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
## Summary

This pull request fixes the LICENSE file to comply with the terms of the MIT License.

## Changes

- Added the original copyright:
  - `Copyright (c) 2024 Gabriel de Rezende Gonçalves`
- Added the link to the original project:  
  - [https://github.com/gabireze/tiktok-all-reposted-videos-remover](https://github.com/gabireze/tiktok-all-reposted-videos-remover)
- Kept the copyright:
  - `Copyright (c) 2025 Mohammed Mostafa`
- Kept the full MIT License text without any modifications.

## Reason

According to the MIT License, all copies or substantial portions of the Software must retain the original copyright notice and the permission notice.

## Notes

If you prefer, you can also mention the original repository in your project README for better transparency, but that is optional.

Thank you!
